### PR TITLE
FOIA link changed to OMB link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -50,7 +50,7 @@
           </li>
           <li>
             <a
-              href="https://www.gsa.gov/reference/freedom-of-information-act-foia"
+              href="https://www.whitehouse.gov/omb/freedom-of-information-act-foia/"
               class="usa-link usa-link--external"
               rel="noreferrer" target="_blank"
             >


### PR DESCRIPTION
Updating link behind FOIA to point to OMB page. @scottqueen-bixal can you please add @saz33m as a reviewer? takes care of: https://trello.com/c/CfYfqGCK