### PR TITLE
Resolves SRI conflict within cypress tests

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,6 +91,8 @@ footer_navigation:
     children:
       - name: About This Site
         url: /about/
+      - name: Urgent Waivers
+        url: /about/urgent-waivers/
   - name: Policies
     children:
       - name: Accessibility

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,20 +1,24 @@
 <aside class="usa-layout-docs-sidenav desktop:grid-col-3 padding-bottom-4">
+    {% assign paths = page.url | split:'/' %}
   <nav>
     <ul class="usa-sidenav">
       <li class="usa-sidenav__item">
-        <a href="{{ site.baseurl }}/about/" {% if page.url == "/about/" %}class="usa-current"{% endif %}>Our Website</a>
-        {% if page.url == "/about/" %}
+        <a href="{{ site.baseurl }}/about/" {% if paths[1] == "about" %}class="usa-current"{% endif %}>Our Website</a>
+
+        {% if paths[1] == "about" %}
         <ul class="usa-sidenav__sublist">
           <li class="usa-sidenav__item">
             <a href="{{ site.baseurl }}/about/" {% if page.url == "/about/" %}class="usa-current"{% endif %}>About This Site</a>
+          </li>
+          <li class="usa-sidenav__item">
+            <a href="{{ site.baseurl }}/about/urgent-waivers/" {% if page.url == "/about/urgent-waivers/" %}class="usa-current"{% endif %}>Urgent Waivers</a>
           </li>
         </ul>
         {% endif %}
       </li>
       <li class="usa-sidenav__item">
-        {% assign policy_check = page.url | split:'/' %}
-        <a href="{{ site.baseurl }}/policies/accessibility/" {% if policy_check[1] == "policies" %}class="usa-current"{% endif %}>Policies </a>
-        {% if policy_check[1] == "policies" %}
+        <a href="{{ site.baseurl }}/policies/accessibility/" {% if paths[1] == "policies" %}class="usa-current"{% endif %}>Policies </a>
+        {% if paths[1] == "policies" %}
 
         <ul class="usa-sidenav__sublist">
           <li class="usa-sidenav__item">
@@ -33,9 +37,8 @@
         {% endif %}
     </li>
       <li class="usa-sidenav__item">
-        {% assign service_check = page.url | split:'/' %}
-        <a href="{{ site.baseurl }}/customer-service/support/" {% if service_check[1] == "customer-service" %}class="usa-current"{% endif %}>Customer Service</a>
-        {% if service_check[1] == "customer-service" %}
+        <a href="{{ site.baseurl }}/customer-service/support/" {% if paths[1] == "customer-service" %}class="usa-current"{% endif %}>Customer Service</a>
+        {% if paths[1] == "customer-service" %}
         <ul class="usa-sidenav__sublist">
           <li class="usa-sidenav__item">
             <a href="{{ site.baseurl }}/customer-service/support/" {% if page.url == "/customer-service/support/" %}class="usa-current"{% endif %}>Government Customer Support</a>

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -8,6 +8,38 @@ description: "Resources for more information about small businesses, becoming a 
 
 # Resources
 
+Below is contact information for agencies subject to the Chief Financial Officers Act (CFO Act).
+
+| CFO Act Agency                                |   Point of Contact Email   |
+| --------------------------------------------- | :------------------------: |
+| Department of Agriculture                     |       <press@usda.gov>       |
+| Department of Commerce                        |          pending           |
+| Department of Defense                         |          pending           |
+| Department of Education                       |        <press@ed.gov>        |
+| Department of Energy                          |     <DOENEWS@hq.doe.gov>     |
+| Department of Health and Human Services       |       <media@hhs.gov>        |
+| Department of Homeland Security               |  <mediainquiry@hq.dhs.gov>   |
+| Department of Housing and Urban Development   |          pending           |
+| Department of Interior                        | <interior_press@ios.doi.gov> |
+| Department of Justice                         |          pending           |
+| Department of Labor                           |          pending           |
+| Department of State                           |   <PAPressDuty@state.gov>    |
+| Department of Transportation                  |    <Pressoffice@dot.gov>     |
+| Department of Treasury                        |     <press@treasury.gov>     |
+| Department of Veterans Affairs                |   <VAPublicAffairs@va.gov>   |
+| Environmental Protection Agency               |       <press@epa.gov>        |
+| National Aeronautics and Space Administration |          pending           |
+| Agency for International Development          |      <press@usaid.gov>       |
+| Social Security Administration                |          pending           |
+| General Services Administration               |          pending           |
+| National Science Foundation                   |          pending           |
+| Office of Personnel Management                |       <media@opm.gov>        |
+| Small Business Administration                 |    <press_office@sba.gov>    |
+
+For all other agencies covered by Executive Order 14005, please find contact information at [https://www.usa.gov/federal-agencies](https://www.usa.gov/federal-agencies){:target="_blank" rel="noreferrer" class="usa-link--external"}.
+
+Other resources:
+
 - [Visit the U.S. Small Business Administration's website for more information for and about small businesses.](https://www.sba.gov/){:target="_blank" rel="noreferrer" class="usa-link--external"}
 
 - [Visit SAM.gov to register to do business with the U.S. government.](https://www.sam.gov){:target="_blank" rel="noreferrer" class="usa-link--external"}

--- a/_pages/urgent-waivers.md
+++ b/_pages/urgent-waivers.md
@@ -1,0 +1,15 @@
+---
+permalink: /about/urgent-waivers/
+layout: page
+title: Urgent Waivers
+sidenav: true
+description: "MadeinAmerica.gov is the public facing website providing information about Executive Order 14005: Ensuring the Future is Made in America by All of America’s Workers."
+---
+
+# Urgent Waivers
+
+When agencies are obligated by law to act more quickly than the review procedures allow due to urgent requirements, urgent waivers may be issued by the agency. These waivers are infrequent and will be shared on this page when available.
+
+For additional information on these waivers, please contact the issuing agency using the points of contact at our *[resources page.](https://www.madeinamerica.gov/customer-service/resources/){:target="_blank" rel="noreferrer"}*
+
+

--- a/cypress.json
+++ b/cypress.json
@@ -5,6 +5,7 @@
   ],
   "video": false,
   "chromeWebSecurity": false,
+  "experimentalSourceRewriting": true,
   "nodeVersion": "system"
 }
 


### PR DESCRIPTION
cypress, running chrome `--detached`, was blocking our js resource because of [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity). 

It seems that we can rewrite the resources within cypress runner using `"experimentalSourceRewriting": true` set in our config.

Note this also updates with the latest from `develop`