### PR TITLE
[mia-185] non-availability test hot fix 

### DIFF
--- a/cypress/integration/tests/non-availability-check.spec.js
+++ b/cypress/integration/tests/non-availability-check.spec.js
@@ -3,9 +3,12 @@ describe('non-availability check', () => {
   it('non-availability should not be present on site', () => {
     cy.getUrlsArray().then($urls => {
       $urls.forEach(url => {
-        cy.visit(url)
-        cy.contains('non-availability').should('not.exist')
-        cy.contains('Non-availability').should('not.exist')
+        if (url !== 'http://localhost:4000/waivers/') {
+          // skipping the wiavers page because that is the only page that is dynamic within the site... test coverge for that wiavers page for this can be found in the 'results-display.spec.js' file within the wiaver-app file
+          cy.visit(url)
+          cy.contains('non-availability').should('not.exist')
+          cy.contains('Non-availability').should('not.exist')
+        }
       })
     })
   })


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant. -->

## Description

the cypress pipeline was failing on the 'non-availability-check.spec' the test checks that content on the site does not include the term 'non-availability' however within the waivers there were some that did have 'non-availability' since this is the only dynamic page on the site this test is now written to skip that page however coverage will be provided for that page in the 'results-display.spec' file.

Ticket reference: https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=3351&projectKey=MIA&view=detail&selectedIssue=MIA-185

## How to test

- npm install 
- npm run start 
- split terminal 
- npm run test (this will run the full pipeline on local)

## Additional information

Include any of the following (as necessary):

- this will help get the pipeline working as expected and get test coverage back to where it was 

see PR for waivers page coverage: https://github.com/GSA/made-in-america/pull/143

To prepare for code review, please follow the following checks.

- [x] branch has detailed description of work/updates
- [x] title format follows: `[Ticket Number] : Brief statement describing what this pull request solves`.
- [x] passed all integrated testing
- [x] pipeline has completed successfully
- [x] federalist preview has been generated
- [x] code review/design review requested as appropriate
- [x] branch/preview link updated in ticket
