### PR TITLE
fix print icon not showing issue

### DIFF
--- a/waiver-form/index.html
+++ b/waiver-form/index.html
@@ -17,17 +17,17 @@ title: Waiver Form
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://cdn.form.io/formiojs/formio.full.min.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
       href="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.12.1/css/uswds.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
       href="https://unpkg.com/@formio/uswds@2.4.0/dist/uswds.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.form.io/formiojs/formio.full.min.css"
     />
     <script src="https://cdn.form.io/formiojs/formio.full.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.12.1/js/uswds.min.js"></script>


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant. -->

## Description

Formio container theme is being overridden and rearrange the order to resolve it.

## How to test

- Make sure formio.full.min.css is the last css in the list of all css files in waiver-form/index.html file.

