### PR TITLE
[MIA-392] fix mailto link on FAQ page 

### DIFF
--- a/_includes/faqs.html
+++ b/_includes/faqs.html
@@ -77,7 +77,7 @@
               Office at
               <a
                 class="text-base-lightest usa-link--external"
-                href="mailto:MadeInAmerica@omb.eop.gov:"
+                href="mailto:MadeInAmerica@omb.eop.gov"
                 rel="noreferrer"
                 target="_blank"
                 >MadeInAmerica@omb.eop.gov.</a


### PR DESCRIPTION

## Description

Mailto link had an unneeded ':' and was causing users to have issues.  link to ticket https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=3372&projectKey=MIA&view=detail&selectedIssue=MIA-391
## How to test

- Steps on how to test the integration/feature/fix
- pull down code 
- run `npm run start`
- go to `localhost:4000` in browser
- visit the FAQ "What if i want to make comments to a waiver" and select the link in FAQ and make sure that there is not a ":" at the end of the address 

To prepare for code review, please follow the following checks.

- [x] branch has detailed description of work/updates
- [x] title format follows: `[Ticket Number] : Brief statement describing what this pull request solves`.
- [x] passed all integrated testing
- [x] pipeline has completed successfully
- [x] federalist preview has been generated
- [x] code review/design review requested as appropriate
- [x] branch/preview link updated in ticket
