### PR TITLE
Added new FAQ re: MEP

### DIFF
--- a/_includes/faqs.html
+++ b/_includes/faqs.html
@@ -308,6 +308,46 @@
             </p>
           </div>
           <!-- end accordion item -->
+          <!-- start accordion item -->
+          <h3 class="usa-accordion__heading">
+            <button
+              class="usa-accordion__button"
+              aria-expanded="false"
+              aria-controls="faq-10"
+            >
+              What is the Hollings Manufacturing Extension Partnership (MEP)
+              and where can I find out more about it?
+            </button>
+          </h3>
+          <div
+            id="faq-10"
+            class="usa-accordion__content usa-prose bg-primary-darker text-base-lightest"
+          >
+            <p>
+              MEP is a public-private partnership with Centers in all 50 states
+              and Puerto Rico dedicated to serving small and medium-sized 
+              manufacturers. Supplier Scouting is a successful nationwide MEP 
+              service that identifies domestic manufacturers to produce 
+              hard-to-source and critically needed supply chain items including
+              personal protective equipment (PPE) and medical supplies. Supplier 
+              Scouting can be applied on a national, regional or local scale. 
+              By leveraging our extensive relationships and knowledge of 
+              U.S. manufacturer capabilities, we are able to identify 
+              manufacturers’ production and technical capabilities and connect 
+              them with supply chains of larger companies and government agencies. 
+              For more information about Supplier Scouting, please contact the 
+              MEP supplier scouting team at
+              <a
+                class="text-base-lightest usa-link--external"
+                href="mailto:scouting@nist.gov"
+                rel="noreferrer"
+                target="_blank"
+                >MadeInAmerica@omb.eop.gov</a
+              >.
+              >              
+            </p>
+          </div>
+          <!-- end accordion item -->
         </div>
       </div>
 


### PR DESCRIPTION
Related to jira ticket [MIA-474]

New FAQ added FAQ 10 at bottom of list. 

Copy from client - 
Question:  What is the Hollings Manufacturing Extension Partnership (MEP) and where can I find out more about it?  
Answer: MEP is a public-private partnership with Centers in all 50 states and Puerto Rico dedicated to serving small and medium-sized manufacturers. Supplier Scouting is a successful nationwide MEP service that identifies domestic manufacturers to produce hard-to-source and critically needed supply chain items including personal protective equipment (PPE) and medical supplies. Supplier Scouting can be applied on a national, regional or local scale. By leveraging our extensive relationships and knowledge of U.S. manufacturer capabilities, we are able to identify manufacturers’ production and technical capabilities and connect them with supply chains of larger companies and government agencies. For more information about Supplier Scouting, please contact the MEP supplier scouting team ([scouting@nist.gov](mailto:scouting@nist.gov)). 

Ready for test by @clmedders and if correct on to @Mesele29 